### PR TITLE
Add namespace for apps as it is passed to pipelines.

### DIFF
--- a/apps.tf
+++ b/apps.tf
@@ -16,6 +16,7 @@ module "apps" {
   ad_aws_ssm_document_name        = "${module.ad.ad_aws_ssm_document_name}"
   ad_writer_instance_profile_name = "${module.ad.ad_writer_instance_profile_name}"
   naming_suffix                   = "${local.naming_suffix}"
+  namespace                       = "${var.NAMESPACE}"
 
   s3_bucket_name = {
     archive_log       = "s3-dq-log-archive-bucket-${var.NAMESPACE}"


### PR DESCRIPTION
This is required for dq-tf-infra after https://github.com/UKHomeOffice/dq-tf-apps/pull/123 has been merged.