### PR TITLE
IAM Role Policy update - AWS SSM Run Command remediation end of support for ec2messages

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -119,7 +119,14 @@ resource "aws_iam_policy" "write_to_cw_new" {
           "ec2messages:SendReply",
           "ds:CreateComputer",
           "ds:DescribeDirectories",
-          "ec2:DescribeInstanceStatus"
+          "ec2:DescribeInstanceStatus",
+          # ─────────────────────────────────────────────────────────────
+          # NEW ssmmessages permissions (required after 16 June 2026)
+          # ─────────────────────────────────────────────────────────────
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
       ],
       "Resource": [
           "*"

--- a/iam.tf
+++ b/iam.tf
@@ -140,10 +140,7 @@ resource "aws_iam_role_policy_attachment" "ops_win_ssm_core" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 
   lifecycle {
-    ignore_changes = [
-      role,
-      policy_arn ,
-    ]
+    prevent_destroy = true
   }
 }
 
@@ -152,9 +149,6 @@ resource "aws_iam_role_policy_attachment" "ops_win_tableau_ssm_core" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 
   lifecycle {
-    ignore_changes = [
-      role,
-      policy_arn ,
-    ]
+    prevent_destroy = true
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -140,7 +140,10 @@ resource "aws_iam_role_policy_attachment" "ops_win_ssm_core" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 
   lifecycle {
-    prevent_destroy = true
+    ignore_changes = [
+      role,
+      policy_arn ,
+    ]
   }
 }
 
@@ -149,6 +152,9 @@ resource "aws_iam_role_policy_attachment" "ops_win_tableau_ssm_core" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 
   lifecycle {
-    prevent_destroy = true
+    ignore_changes = [
+      role,
+      policy_arn ,
+    ]
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -135,12 +135,12 @@ EOF
 # Protected with lifecycle block to prevent accidental destruction in Prod
 # =============================================================================
 
-resource "aws_iam_role_policy_attachment" "ops_win_ssm_core" {
-  role       = "ops-win"
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
+#resource "aws_iam_role_policy_attachment" "ops_win_ssm_core" {
+#  role       = "ops-win"
+#  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+#}
 
-resource "aws_iam_role_policy_attachment" "ops_win_tableau_ssm_core" {
-  role       = "ops-win-tableau"
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
+#resource "aws_iam_role_policy_attachment" "ops_win_tableau_ssm_core" {
+#  role       = "ops-win-tableau"
+#  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+#}

--- a/iam.tf
+++ b/iam.tf
@@ -130,3 +130,25 @@ resource "aws_iam_policy" "write_to_cw_new" {
 EOF
 
 }
+# =============================================================================
+# FIX FOR SSM RUN COMMAND (required before 16 June 2026)
+# Protected with lifecycle block to prevent accidental destruction in Prod
+# =============================================================================
+
+resource "aws_iam_role_policy_attachment" "ops_win_ssm_core" {
+  role       = "ops-win"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+
+  #lifecycle {
+  #  prevent_destroy = true
+  #}
+}
+
+resource "aws_iam_role_policy_attachment" "ops_win_tableau_ssm_core" {
+  role       = "ops-win-tableau"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+
+  #lifecycle {
+  #  prevent_destroy = true
+  #}
+}

--- a/iam.tf
+++ b/iam.tf
@@ -139,16 +139,16 @@ resource "aws_iam_role_policy_attachment" "ops_win_ssm_core" {
   role       = "ops-win"
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 
-  #lifecycle {
-  #  prevent_destroy = true
-  #}
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "ops_win_tableau_ssm_core" {
   role       = "ops-win-tableau"
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 
-  #lifecycle {
-  #  prevent_destroy = true
-  #}
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -130,16 +130,3 @@ resource "aws_iam_policy" "write_to_cw_new" {
 EOF
 
 }
-# =============================================================================
-# FIX FOR SSM RUN COMMAND (required before 16 June 2026)
-# =============================================================================
-
-resource "aws_iam_role_policy_attachment" "ops_win_ssm_core" {
-  role       = "ops-win"
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-
-resource "aws_iam_role_policy_attachment" "ops_win_tableau_ssm_core" {
-  role       = "ops-win-tableau"
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}

--- a/iam.tf
+++ b/iam.tf
@@ -138,17 +138,9 @@ EOF
 resource "aws_iam_role_policy_attachment" "ops_win_ssm_core" {
   role       = "ops-win"
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_iam_role_policy_attachment" "ops_win_tableau_ssm_core" {
   role       = "ops-win-tableau"
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -132,15 +132,14 @@ EOF
 }
 # =============================================================================
 # FIX FOR SSM RUN COMMAND (required before 16 June 2026)
-# Protected with lifecycle block to prevent accidental destruction in Prod
 # =============================================================================
 
-#resource "aws_iam_role_policy_attachment" "ops_win_ssm_core" {
-#  role       = "ops-win"
-#  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-#}
+resource "aws_iam_role_policy_attachment" "ops_win_ssm_core" {
+  role       = "ops-win"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
 
-#resource "aws_iam_role_policy_attachment" "ops_win_tableau_ssm_core" {
-#  role       = "ops-win-tableau"
-#  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-#}
+resource "aws_iam_role_policy_attachment" "ops_win_tableau_ssm_core" {
+  role       = "ops-win-tableau"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}

--- a/iam.tf
+++ b/iam.tf
@@ -120,9 +120,6 @@ resource "aws_iam_policy" "write_to_cw_new" {
           "ds:CreateComputer",
           "ds:DescribeDirectories",
           "ec2:DescribeInstanceStatus",
-          # ─────────────────────────────────────────────────────────────
-          # NEW ssmmessages permissions (required after 16 June 2026)
-          # ─────────────────────────────────────────────────────────────
           "ssmmessages:CreateControlChannel",
           "ssmmessages:CreateDataChannel",
           "ssmmessages:OpenControlChannel",


### PR DESCRIPTION
AWS Health has notified us that two EC2 instance roles (ops-win and ops-win-tableau) are using the legacy ec2messages endpoints. These will be deprecated on 16 June 2026.
This change attaches the official AWS managed policy AmazonSSMManagedInstanceCore to both roles so they switch to the new ssmmessages endpoints.